### PR TITLE
Add lfe compiler

### DIFF
--- a/src/rebar.app.src
+++ b/src/rebar.app.src
@@ -31,6 +31,7 @@
                      rebar_prv_install_deps,
                      rebar_prv_packages,
                      rebar_prv_erlydtl_compiler,
+                     rebar_prv_lfe_compiler,
                      rebar_prv_compile,
                      rebar_prv_app_discovery,
                      rebar_prv_shell,

--- a/src/rebar_lfe_compiler.erl
+++ b/src/rebar_lfe_compiler.erl
@@ -1,0 +1,84 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+%% -------------------------------------------------------------------
+%%
+%% rebar: Erlang Build Tools
+%%
+%% Copyright (c) 2009 Dave Smith (dizzyd@dizzyd.com),
+%%                    Tim Dysinger (tim@dysinger.net)
+%%
+%% Permission is hereby granted, free of charge, to any person obtaining a copy
+%% of this software and associated documentation files (the "Software"), to deal
+%% in the Software without restriction, including without limitation the rights
+%% to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+%% copies of the Software, and to permit persons to whom the Software is
+%% furnished to do so, subject to the following conditions:
+%%
+%% The above copyright notice and this permission notice shall be included in
+%% all copies or substantial portions of the Software.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+%% IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+%% FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+%% AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+%% LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+%% OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+%% THE SOFTWARE.
+%% -------------------------------------------------------------------
+
+-module(rebar_lfe_compiler).
+
+-export([compile/2]).
+
+%% for internal use only
+-export([info/2]).
+
+-include("rebar.hrl").
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+compile(Config, _AppFile) ->
+    FirstFiles = rebar_config:get_list(Config, lfe_first_files, []),
+    rebar_base_compiler:run(Config, FirstFiles, "src", ".lfe", "ebin", ".beam",
+                            fun compile_lfe/3).
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
+
+info(help, compile) ->
+    ?CONSOLE(
+       "Build Lisp Flavoured Erlang (*.lfe) sources.~n"
+       "~n"
+       "Valid rebar.config options:~n"
+       "  erl_opts is reused.'~n",
+       []).
+
+compile_lfe(Source, _Target, Config) ->
+    case code:which(lfe_comp) of
+        non_existing ->
+            ?ERROR("~n"
+                   "*** MISSING LFE COMPILER ***~n"
+                   "  You must do one of the following:~n"
+                   "    a) Install LFE globally in your erl libs~n"
+                   "    b) Add LFE as a dep for your project, eg:~n"
+                   "       {lfe, \"0.6.1\",~n"
+                   "        {git, \"git://github.com/rvirding/lfe\",~n"
+                   "         {tag, \"v0.6.1\"}}}~n"
+                   "~n", []),
+            ?FAIL;
+        _ ->
+            ErlOpts = rebar_utils:erl_opts(Config),
+            Opts = [{i, "include"}, {outdir, "ebin"}, return] ++ ErlOpts,
+            case lfe_comp:file(Source, Opts) of
+                {ok, _Mod, Ws} ->
+                    rebar_base_compiler:ok_tuple(Config, Source, Ws);
+                {error, Es, Ws} ->
+                    rebar_base_compiler:error_tuple(Config, Source,
+                                                    Es, Ws, Opts);
+                _ ->
+                    ?FAIL
+            end
+    end.

--- a/src/rebar_lfe_compiler.erl
+++ b/src/rebar_lfe_compiler.erl
@@ -70,9 +70,9 @@ compile_lfe(Source, _Target, Config) ->
                    "  You must do one of the following:~n"
                    "    a) Install LFE globally in your erl libs~n"
                    "    b) Add LFE as a dep for your project, eg:~n"
-                   "       {lfe, \"0.6.1\",~n"
+                   "       {lfe, \"0.9.0\",~n"
                    "        {git, \"git://github.com/rvirding/lfe\",~n"
-                   "         {tag, \"v0.6.1\"}}}~n"
+                   "         {tag, \"v0.9.0\"}}}~n"
                    "~n", []),
             ?FAIL;
         _ ->

--- a/src/rebar_lfe_compiler.erl
+++ b/src/rebar_lfe_compiler.erl
@@ -39,10 +39,16 @@
 %% Public API
 %% ===================================================================
 
-compile(Config, _AppFile) ->
+compile(Config, Dir) ->
     FirstFiles = rebar_config:get_list(Config, lfe_first_files, []),
-    rebar_base_compiler:run(Config, FirstFiles, "src", ".lfe", "ebin", ".beam",
-                            fun compile_lfe/3).
+    rebar_base_compiler:run(Config,
+                            check_files(rebar_state:get(
+                                          Config, lfe_first_files, [])),
+                            filename:join(Dir, "src"),
+                            ".lfe",
+                            filename:join(Dir, "ebin"),
+                            ".beam",
+                            fun compile_lfe/3),
 
 %% ===================================================================
 %% Internal functions

--- a/src/rebar_prv_lfe_compiler.erl
+++ b/src/rebar_prv_lfe_compiler.erl
@@ -54,7 +54,7 @@ init(State) ->
         {example, "rebar lfecompile"},
         {short_desc, ?DESC},
         {desc, info(?DESC)},
-        {opts, []}
+        {opts, [{undefined, undefined, undefined, undefined, ""}]}
     ]),
     State1 = rebar_state:add_provider(State, Provider),
     {ok, State1}.

--- a/src/rebar_prv_lfe_compiler.erl
+++ b/src/rebar_prv_lfe_compiler.erl
@@ -39,7 +39,7 @@
 
 -include("rebar.hrl").
 
--define(PROVIDER, lfe).
+-define(PROVIDER, lfecompile).
 -define(DEPS, []).
 
 %% ===================================================================
@@ -53,7 +53,7 @@ init(State) ->
         {module, ?MODULE},
         {bare, false},
         {deps, ?DEPS},
-        {example, "rebar lfe compile"},
+        {example, "rebar lfecompile"},
         {short_desc, "Compile LFE source files."},
         {desc, get_info()},
         {opts, []}

--- a/src/rebar_prv_lfe_compiler.erl
+++ b/src/rebar_prv_lfe_compiler.erl
@@ -34,12 +34,10 @@
          do/1,
          format_error/1]).
 
-%% for internal use only
--export([info/2]).
-
 -include("rebar.hrl").
 
 -define(PROVIDER, lfecompile).
+-define(DESC, "Compile LFE source files.").
 -define(DEPS, []).
 
 %% ===================================================================
@@ -54,8 +52,8 @@ init(State) ->
         {bare, false},
         {deps, ?DEPS},
         {example, "rebar lfecompile"},
-        {short_desc, "Compile LFE source files."},
-        {desc, get_info()},
+        {short_desc, ?DESC},
+        {desc, info(?DESC)},
         {opts, []}
     ]),
     State1 = rebar_state:add_provider(State, Provider),
@@ -80,19 +78,15 @@ format_error(Reason) ->
 %% ===================================================================
 %% Internal functions
 %% ===================================================================
-get_info() ->
-    get_info(help, compile).
-
-get_info(help, compile) ->
-    (io_lib:format(
-       "Build Lisp Flavoured Erlang (*.lfe) sources.~n"
-       "~n"
-       "Valid rebar.config options:~n"
-       "  erl_opts is reused.~n",
-       [])).
-
-info(help, compile) ->
-    ?CONSOLE(get_info(help, compile), []).
+info(Description) ->
+    io_lib:format(
+        "~n~s~n"
+        "~n"
+        "No additional configuration options are required to compile~n"
+        "LFE (*.lfe) files. The rebar 'erl_opts' setting is reused by~n"
+        "LFE. For more information, see the rebar documentation for~n"
+        "'erl_opts'.",
+        [Description]).
 
 compile_lfe(Source, _Target, State) ->
     case code:which(lfe_comp) of

--- a/src/rebar_prv_lfe_compiler.erl
+++ b/src/rebar_prv_lfe_compiler.erl
@@ -55,7 +55,7 @@ init(State) ->
         {deps, ?DEPS},
         {example, "rebar lfe compile"},
         {short_desc, "Compile LFE source files."},
-        {desc, info()},
+        {desc, get_info()},
         {opts, []}
     ]),
     State1 = rebar_state:add_provider(State, Provider),
@@ -80,16 +80,19 @@ format_error(Reason) ->
 %% ===================================================================
 %% Internal functions
 %% ===================================================================
-info() ->
-    info(help, compile).
+get_info() ->
+    get_info(help, compile).
 
-info(help, compile) ->
-    ?CONSOLE(
+get_info(help, compile) ->
+    (io_lib:format(
        "Build Lisp Flavoured Erlang (*.lfe) sources.~n"
        "~n"
        "Valid rebar.config options:~n"
        "  erl_opts is reused.~n",
-       []).
+       [])).
+
+info(help, compile) ->
+    ?CONSOLE(get_info(help, compile), []).
 
 compile_lfe(Source, _Target, State) ->
     case code:which(lfe_comp) of


### PR DESCRIPTION
This isn't intended to be merged. This PR is provided for ease of viewing. After completing this and having discussions in this ticket:
- https://github.com/rebar/rebar3/issues/29

the intent for this work evolved into the idea of establishing a top-level namespace for LFE rebar3 plugins, with this branch becoming its own plugin using the LFE namepsace.

**Update**: repo created to bring the code from this PR into its own plugin here:
- https://github.com/oubiwann/rebar3-lfe-compile

Note that this also has the related rebar3 tickets/PRs, for anyone wanting to catch up on the full context here:
- https://github.com/rebar/rebar3/issues/64 - "Proposal for plugin-based development"
- https://github.com/rebar/rebar3/issues/69 - "Major Providers Refactoring"
- https://github.com/rebar/rebar3/pull/70 - "Provider namespaces"
- https://github.com/rebar/rebar3/issues/30 - "Running help with providers that have no options defined causes badmatch error"

And, of course, the full docs here:
- http://www.rebar3.org/v3.0/docs
